### PR TITLE
Adding ability to use pre-generated models.

### DIFF
--- a/cmd/swagger/commands/generate/client.go
+++ b/cmd/swagger/commands/generate/client.go
@@ -46,6 +46,10 @@ func (c *Client) Execute(args []string) error {
 	}
 	setDebug(cfg)
 
+	if c.ExistingModels != "" {
+		c.SkipModels = true
+	}
+
 	opts := &generator.GenOpts{
 		Spec: string(c.Spec),
 

--- a/cmd/swagger/commands/generate/model.go
+++ b/cmd/swagger/commands/generate/model.go
@@ -17,6 +17,7 @@ package generate
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -37,6 +38,10 @@ func (m *Model) Execute(args []string) error {
 
 	if m.DumpData && len(m.Name) > 1 {
 		return errors.New("only 1 model at a time is supported for dumping data")
+	}
+
+	if m.ExistingModels != "" {
+		log.Println("Warning: Ignoring existing-models flag when generating models.")
 	}
 
 	cfg, err := readConfig(string(m.ConfigFile))

--- a/cmd/swagger/commands/generate/server.go
+++ b/cmd/swagger/commands/generate/server.go
@@ -52,6 +52,10 @@ func (s *Server) Execute(args []string) error {
 	}
 	setDebug(cfg)
 
+	if s.ExistingModels != "" {
+		s.SkipModels = true
+	}
+
 	opts := &generator.GenOpts{
 		Spec:              string(s.Spec),
 		Target:            string(s.Target),
@@ -80,6 +84,7 @@ func (s *Server) Execute(args []string) error {
 		Name:              s.Name,
 		FlagStrategy:      s.FlagStrategy,
 		CompatibilityMode: s.CompatibilityMode,
+		ExistingModels:    s.ExistingModels,
 	}
 
 	if e := opts.EnsureDefaults(false); e != nil {

--- a/cmd/swagger/commands/generate/shared.go
+++ b/cmd/swagger/commands/generate/shared.go
@@ -11,14 +11,15 @@ import (
 )
 
 type shared struct {
-	Spec          flags.Filename `long:"spec" short:"f" description:"the spec file to use (default swagger.{json,yml,yaml})"`
-	APIPackage    string         `long:"api-package" short:"a" description:"the package to save the operations" default:"operations"`
-	ModelPackage  string         `long:"model-package" short:"m" description:"the package to save the models" default:"models"`
-	ServerPackage string         `long:"server-package" short:"s" description:"the package to save the server specific code" default:"restapi"`
-	ClientPackage string         `long:"client-package" short:"c" description:"the package to save the client specific code" default:"client"`
-	Target        flags.Filename `long:"target" short:"t" default:"./" description:"the base directory for generating the files"`
-	TemplateDir   flags.Filename `long:"template-dir" short:"T" description:"alternative template override directory"`
-	ConfigFile    flags.Filename `long:"config-file" short:"C" description:"configuration file to use for overriding template options"`
+	Spec           flags.Filename `long:"spec" short:"f" description:"the spec file to use (default swagger.{json,yml,yaml})"`
+	APIPackage     string         `long:"api-package" short:"a" description:"the package to save the operations" default:"operations"`
+	ModelPackage   string         `long:"model-package" short:"m" description:"the package to save the models" default:"models"`
+	ServerPackage  string         `long:"server-package" short:"s" description:"the package to save the server specific code" default:"restapi"`
+	ClientPackage  string         `long:"client-package" short:"c" description:"the package to save the client specific code" default:"client"`
+	Target         flags.Filename `long:"target" short:"t" default:"./" description:"the base directory for generating the files"`
+	TemplateDir    flags.Filename `long:"template-dir" short:"T" description:"alternative template override directory"`
+	ConfigFile     flags.Filename `long:"config-file" short:"C" description:"configuration file to use for overriding template options"`
+	ExistingModels string         `long:"existing-models" description:"use pre-generated models e.g. github.com/foobar/model"`
 }
 
 func readConfig(filename string) (*viper.Viper, error) {

--- a/generator/client.go
+++ b/generator/client.go
@@ -23,8 +23,8 @@ import (
 	"sort"
 
 	"github.com/go-openapi/analysis"
-	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/loads"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/swag"
 )
 
@@ -114,7 +114,10 @@ func (c *clientGenerator) Generate() error {
 	if app.Name == "" {
 		app.Name = "APIClient"
 	}
-	app.DefaultImports = []string{filepath.ToSlash(filepath.Join(baseImport(c.Target), c.ModelsPackage))}
+	app.DefaultImports = []string{c.GenOpts.ExistingModels}
+	if c.GenOpts.ExistingModels == "" {
+		app.DefaultImports = []string{filepath.ToSlash(filepath.Join(baseImport(c.Target), c.ModelsPackage))}
+	}
 	if err != nil {
 		return err
 	}
@@ -149,7 +152,7 @@ func (c *clientGenerator) Generate() error {
 		sort.Sort(app.OperationGroups)
 		for i := range app.OperationGroups {
 			opGroup := app.OperationGroups[i]
-			opGroup.DefaultImports = []string{filepath.ToSlash(filepath.Join(baseImport(c.Target), c.ModelsPackage))}
+			opGroup.DefaultImports = app.DefaultImports
 			opGroup.RootPackage = c.ClientPackage
 			app.OperationGroups[i] = opGroup
 			sort.Sort(opGroup.Operations)

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -191,12 +191,16 @@ func (o *operationGenerator) Generate() error {
 	bldr.Analyzed = o.Analyzed
 	bldr.DefaultScheme = o.DefaultScheme
 	bldr.DefaultProduces = o.DefaultProduces
-	bldr.DefaultImports = []string{filepath.ToSlash(filepath.Join(baseImport(o.Base), o.ModelsPackage))}
 	bldr.RootAPIPackage = o.APIPackage
 	bldr.WithContext = o.WithContext
 	bldr.GenOpts = o.GenOpts
 	bldr.DefaultConsumes = o.DefaultConsumes
 	bldr.IncludeValidator = o.IncludeValidator
+
+	bldr.DefaultImports = []string{o.GenOpts.ExistingModels}
+	if o.GenOpts.ExistingModels == "" {
+		bldr.DefaultImports = []string{filepath.ToSlash(filepath.Join(baseImport(o.Base), o.ModelsPackage))}
+	}
 
 	bldr.APIPackage = bldr.RootAPIPackage
 	st := o.Tags

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -30,11 +30,11 @@ import (
 	swaggererrors "github.com/go-openapi/errors"
 
 	"github.com/go-openapi/analysis"
-	"github.com/go-openapi/validate"
-	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/spec"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 	"golang.org/x/tools/imports"
 )
 
@@ -334,6 +334,7 @@ type GenOpts struct {
 	Name              string
 	FlagStrategy      string
 	CompatibilityMode string
+	ExistingModels    string
 }
 
 // TargetPath returns the target path relative to the server package

--- a/generator/support.go
+++ b/generator/support.go
@@ -520,6 +520,10 @@ func (a *appGenerator) makeCodegenApp() (GenApp, error) {
 
 	var genMods []GenDefinition
 	importPath := filepath.ToSlash(filepath.Join(baseImport(a.Target), a.ModelsPackage))
+	if a.GenOpts.ExistingModels == "" {
+		importPath = filepath.ToSlash(filepath.Join(baseImport(a.Target), a.ModelsPackage))
+	}
+
 	defaultImports = append(defaultImports, importPath)
 
 	log.Println("planning definitions")
@@ -601,6 +605,11 @@ func (a *appGenerator) makeCodegenApp() (GenApp, error) {
 			operation.Package = a.Package
 		}
 		opsGroupedByTag[operation.Package] = append(opsGroupedByTag[operation.Package], operation)
+	}
+
+	modelsPackage := a.GenOpts.ExistingModels
+	if modelsPackage == "" {
+		modelsPackage = filepath.ToSlash(filepath.Join(baseImport(a.Target), a.ModelsPackage))
 	}
 
 	var opGroups GenOperationGroups


### PR DESCRIPTION
Both a client and server can be generated and reference pre-generated
models using the new "existing-models" command-line switch e.g.:

swagger generate server --existing-models="github.com/\<repo\>/models"
swagger generate client --existing-models="github.com/\<repo\>/models"